### PR TITLE
Make API endpoints work with Google Storage

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,1 +1,7 @@
-export { default } from 'ember-writer/adapters/application';
+import ApplicationAdapter from 'ember-writer/adapters/application';
+import config from '../config/environment';
+
+export default ApplicationAdapter.extend({
+  host: config.host,
+  namespace: config.namespace || 'api/blog'
+});

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
   headData: service(),
   model() {
     return {
-      featured: this.store.peekRecord('post', 'mw-thinking-reactively-with-rx-js-5')
+      featured: this.store.findRecord('post', 'mw-thinking-reactively-with-rx-js-5')
     };
   },
   afterModel() {

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -8,7 +8,8 @@ module.exports = function() {
     },
     'gcloud-storage': {
       projectId: 'this-dot',
-      bucket: 'this-dot-assets'
+      bucket: 'this-dot-assets',
+      filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,json}'
     }
   };
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,7 @@
 /* jshint node: true */
 
+const storageHost = '//storage.googleapis.com';
+
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'thisdot',
@@ -21,7 +23,11 @@ module.exports = function(environment) {
 
     googleFonts: [
       'Raleway:500,500i,600,600i'
-    ]
+    ],
+
+    fastboot: {
+      hostWhitelist: [storageHost, /^localhost:\d+$/]
+    }
   };
 
   if (environment === 'development') {
@@ -44,7 +50,8 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    ENV.host = storageHost;
+    ENV.namespace = 'this-dot-assets/api/blog';
   }
 
   return ENV;

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,8 @@
+[
+    {
+      "origin": ["*"],
+      "responseHeader": ["Content-Type"],
+      "method": ["GET"],
+      "maxAgeSeconds": 3600
+    }
+]

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     fingerprint: {
-      prepend: 'https://storage.googleapis.com/this-dot-assets/',
+      prepend: '//storage.googleapis.com/this-dot-assets/'
     },
     sassOptions: {
       includePaths: [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-resolver": "^2.0.3",
     "ember-router-scroll": "jorgelainfiesta/ember-router-scroll#remove-polyfill",
     "ember-scroll-to": "0.5.4",
-    "ember-writer": "this-dot/ember-writer#81a96647b051658e808da0436a434f9698882edd",
+    "ember-writer": "this-dot/ember-writer#7e91f618da3344b1f20256c05e6f0818887dd48a",
     "loader.js": "^4.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
This PR makes `ember-writter` generated API endpoints work with Fastboot when hosted on Google Cloud. 

To make this work, I had to do the following:

1. Configure gcloud-storage deploy plugin to upload json files
2. Use environment-specific host and namespace
3. Whitelist Google Storage host in Fastboot
4. Add CORS settings to Storage bucket

# Configure gcloud-storage deploy plugin to upload json files

The fastboot server is not serving assets. All assets come from the Google Storage bucket. We use `gcloud-storage` plugin to upload all assets to the bucket. By default, `gcloud-storage` does not include `json` files. This option is configured with [`filePattern`](https://github.com/knownasilya/ember-cli-deploy-gcloud-storage/blob/master/index.js#L18) in deploy config. Adding `filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,json}'` causes json files to be uploaded to the storage bucket.

# Use environment-specific host and namespace

When the site runs in production, we need to tell the app to fetch data from the bucket. This is configured via host and namespace property in application adapter. To make this option configurable by the environment, specify host and namespace in `config/environment`

# Whitelist Google Storage host in Fastboot

Fastboot needs to know that it has permission to fetch data from Google Storage. To do this, we need to specify Google Storage host as one of the whitelisted domains in `config/environment`

# Add CORS settings to Storage bucket

Once we start fetching files from Google Storage host, we need to enable CORS on the bucket to give the app permission to fetch the json files. Adding CORS settings is done with `gsutil cors set cors-json-file.json gs://this-dot-assets`. Here is the setting that I used.

```json
[
    {
      "origin": ["*"],
      "responseHeader": ["Content-Type"],
      "method": ["GET"],
      "maxAgeSeconds": 3600
    }
]
```