### PR TITLE
Apply fingerprinting to json files

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     fingerprint: {
+      replaceExtensions: ['html', 'js', 'css', 'json'],
       prepend: '//storage.googleapis.com/this-dot-assets/'
     },
     sassOptions: {


### PR DESCRIPTION
Images in /media directory were not loading on the site because they were using a local path instead of bucket path. Images should have been using fingerprinted path from asset directory instead.

This PR adds a configuration to `ember-cli-build.js` that tells the [broccoli-asset-rev](https://github.com/rickharrison/broccoli-asset-rev) to change paths in `json` files. This causes the json endpoint files to have image paths replaced with fingerprinted version of the bucket.