### PR TITLE
Exclude fastbootAssetMap.json from fingerprinting

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,10 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     fingerprint: {
       replaceExtensions: ['html', 'js', 'css', 'json'],
-      prepend: '//storage.googleapis.com/this-dot-assets/'
+      exclude: ['assets/assetMap.json'],
+      ignore: ['assets/assetMap.json'],
+      prepend: '//storage.googleapis.com/this-dot-assets/',
+      
     },
     sassOptions: {
       includePaths: [


### PR DESCRIPTION
After #23 was merged, Fastboot broke because `fastbootAssetMap.json` got modified fingerprinted and assets that Fastboot relies on got renamed incorrectly.

This PR excludes fastbootAssetMap.json from being fingerprinted. The actual exclude is for `assets/assetMap.json` because that's what the file is called before it's renamed to fastbootAssetMap.json.