### PR TITLE
Upgraded ember-cli-deploy-gcloud to 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-deploy": "1.0.0-beta.1",
     "ember-cli-deploy-build": "0.1.1",
-    "ember-cli-deploy-gcloud": "0.3.0",
+    "ember-cli-deploy-gcloud": "0.3.3",
     "ember-cli-deploy-gcloud-storage": "0.1.2",
     "ember-cli-google-fonts": "2.3.1",
     "ember-cli-head": "0.1.3",


### PR DESCRIPTION
Previous versions of `ember-cli-deploy-gcloud` didn't have the keyword in package.json which caused the plugin to be excluded from the build pipeline.