### PR TITLE
[Critical] Fix subscribe forms for events

### DIFF
--- a/app/components/event-subscribe.js
+++ b/app/components/event-subscribe.js
@@ -1,10 +1,26 @@
 import Ember from 'ember';
 import EmberChimp from 'ember-chimp/components/ember-chimp';
-const { computed } = Ember;
+const { computed, get, isPresent } = Ember;
 
 export default EmberChimp.extend({
   formAction: "//thisdot.us12.list-manage.com/subscribe/post?u=81e8e3fa2a6f79fe97467029a&amp;id=9f8c1ada95",
   buttonText: "Register",
   loadingText: "Loading",
-  isSuccess: computed.equal('chimpState', 'success')
+  isSuccess: computed.equal('chimpState', 'success'),
+
+  handleResponse(response) {
+    this._super(response);
+    let errorMsg = get(response, 'msg');
+    if (response.result === 'error' && isPresent(errorMsg)) {
+      this.set('chimpSays', errorMsg);
+    }
+  },
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+    this.setProperties({
+      chimpSays: '',
+      chimpState: ''
+    });
+  }
 });

--- a/app/templates/components/event-subscribe.hbs
+++ b/app/templates/components/event-subscribe.hbs
@@ -20,6 +20,6 @@
   <button type="submit" class="button action-button">{{buttonText}}</button>
 
   {{#if chimpSays}}
-    <div class="message">{{chimpSays}}</div>
+    <div class="message">{{{chimpSays}}}</div>
   {{/if}}
 {{/if}}

--- a/app/templates/javascript/event.hbs
+++ b/app/templates/javascript/event.hbs
@@ -33,7 +33,7 @@
         </div>
         {{event-subscribe
             class="contact-form javascript-register"
-            action="//thisdot.us12.list-manage.com/subscribe/post?u=81e8e3fa2a6f79fe97467029a&amp;id=1f86539e1b"
+            formAction=model.thisEvent.subscribe
         }}
       </div>
     </div>


### PR DESCRIPTION
This PR fixes MailChimp links to the correct subscribe forms. Unfortunately, there was a horrible mistake, and a hard coded form URL was being used. 